### PR TITLE
Add bundle distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules
 */coverage
 */.npmrc
 npm-debug.log
+/dist
+*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1067 @@
+{
+   "name": "unidiff",
+   "version": "0.0.4",
+   "lockfileVersion": 1,
+   "requires": true,
+   "dependencies": {
+      "@babel/code-frame": {
+         "version": "7.0.0",
+         "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+         "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+         "dev": true,
+         "requires": {
+            "@babel/highlight": "^7.0.0"
+         }
+      },
+      "@babel/highlight": {
+         "version": "7.0.0",
+         "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+         "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+         "dev": true,
+         "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+         }
+      },
+      "@types/estree": {
+         "version": "0.0.39",
+         "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+         "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+         "dev": true
+      },
+      "@types/node": {
+         "version": "10.12.0",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
+         "integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==",
+         "dev": true
+      },
+      "ansi-styles": {
+         "version": "3.2.1",
+         "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+         "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+         "dev": true,
+         "requires": {
+            "color-convert": "^1.9.0"
+         }
+      },
+      "arr-diff": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+         "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+         "dev": true,
+         "requires": {
+            "arr-flatten": "^1.0.1"
+         }
+      },
+      "arr-flatten": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+         "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+         "dev": true
+      },
+      "array-unique": {
+         "version": "0.2.1",
+         "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+         "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+         "dev": true
+      },
+      "balanced-match": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+         "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+         "dev": true
+      },
+      "brace-expansion": {
+         "version": "1.1.11",
+         "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+         "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+         "dev": true,
+         "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+         }
+      },
+      "braces": {
+         "version": "1.8.5",
+         "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+         "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+         "dev": true,
+         "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+         }
+      },
+      "buffer-from": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+         "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+         "dev": true
+      },
+      "builtin-modules": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
+         "integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==",
+         "dev": true
+      },
+      "chalk": {
+         "version": "2.4.1",
+         "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+         "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+         "dev": true,
+         "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+         }
+      },
+      "color-convert": {
+         "version": "1.9.3",
+         "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+         "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+         "dev": true,
+         "requires": {
+            "color-name": "1.1.3"
+         }
+      },
+      "color-name": {
+         "version": "1.1.3",
+         "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+         "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+         "dev": true
+      },
+      "commander": {
+         "version": "2.17.1",
+         "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+         "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+         "dev": true
+      },
+      "concat-map": {
+         "version": "0.0.1",
+         "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+         "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+         "dev": true
+      },
+      "core-util-is": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+         "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+         "dev": true
+      },
+      "deep-equal": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+         "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+         "dev": true
+      },
+      "define-properties": {
+         "version": "1.1.3",
+         "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+         "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+         "dev": true,
+         "requires": {
+            "object-keys": "^1.0.12"
+         }
+      },
+      "defined": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+         "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+         "dev": true
+      },
+      "diff": {
+         "version": "2.2.3",
+         "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+         "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
+      },
+      "duplexer": {
+         "version": "0.1.1",
+         "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+         "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+         "dev": true
+      },
+      "es-abstract": {
+         "version": "1.12.0",
+         "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+         "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+         "dev": true,
+         "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+         }
+      },
+      "es-to-primitive": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+         "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+         "dev": true,
+         "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+         }
+      },
+      "escape-string-regexp": {
+         "version": "1.0.5",
+         "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+         "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+         "dev": true
+      },
+      "estree-walker": {
+         "version": "0.5.2",
+         "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+         "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
+         "dev": true
+      },
+      "esutils": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+         "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+         "dev": true
+      },
+      "expand-brackets": {
+         "version": "0.1.5",
+         "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+         "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+         "dev": true,
+         "requires": {
+            "is-posix-bracket": "^0.1.0"
+         }
+      },
+      "expand-range": {
+         "version": "1.8.2",
+         "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+         "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+         "dev": true,
+         "requires": {
+            "fill-range": "^2.1.0"
+         }
+      },
+      "extglob": {
+         "version": "0.3.2",
+         "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+         "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+         "dev": true,
+         "requires": {
+            "is-extglob": "^1.0.0"
+         }
+      },
+      "faucet": {
+         "version": "0.0.1",
+         "resolved": "https://registry.npmjs.org/faucet/-/faucet-0.0.1.tgz",
+         "integrity": "sha1-WX3PHSGJosBiMhtZHo8VHtIDnZw=",
+         "dev": true,
+         "requires": {
+            "defined": "0.0.0",
+            "duplexer": "~0.1.1",
+            "minimist": "0.0.5",
+            "sprintf": "~0.1.3",
+            "tap-parser": "~0.4.0",
+            "tape": "~2.3.2",
+            "through2": "~0.2.3"
+         },
+         "dependencies": {
+            "deep-equal": {
+               "version": "0.1.2",
+               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
+               "integrity": "sha1-skbCuApXCkfBG+HZvRBw7IeLh84=",
+               "dev": true
+            },
+            "defined": {
+               "version": "0.0.0",
+               "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+               "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+               "dev": true
+            },
+            "minimist": {
+               "version": "0.0.5",
+               "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+               "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY=",
+               "dev": true
+            },
+            "tape": {
+               "version": "2.3.3",
+               "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.3.tgz",
+               "integrity": "sha1-Lnzgox3wn41oUWZKcYQuDKUFevc=",
+               "dev": true,
+               "requires": {
+                  "deep-equal": "~0.1.0",
+                  "defined": "~0.0.0",
+                  "inherits": "~2.0.1",
+                  "jsonify": "~0.0.0",
+                  "resumer": "~0.0.0",
+                  "through": "~2.3.4"
+               }
+            }
+         }
+      },
+      "filename-regex": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+         "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+         "dev": true
+      },
+      "fill-range": {
+         "version": "2.2.4",
+         "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+         "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+         "dev": true,
+         "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+         }
+      },
+      "for-each": {
+         "version": "0.3.3",
+         "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+         "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+         "dev": true,
+         "requires": {
+            "is-callable": "^1.1.3"
+         }
+      },
+      "for-in": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+         "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+         "dev": true
+      },
+      "for-own": {
+         "version": "0.1.5",
+         "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+         "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+         "dev": true,
+         "requires": {
+            "for-in": "^1.0.1"
+         }
+      },
+      "fs.realpath": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+         "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+         "dev": true
+      },
+      "function-bind": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+         "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+         "dev": true
+      },
+      "glob": {
+         "version": "7.1.3",
+         "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+         "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+         "dev": true,
+         "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+         }
+      },
+      "glob-base": {
+         "version": "0.3.0",
+         "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+         "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+         "dev": true,
+         "requires": {
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
+         }
+      },
+      "glob-parent": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+         "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+         "dev": true,
+         "requires": {
+            "is-glob": "^2.0.0"
+         }
+      },
+      "has": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+         "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+         "dev": true,
+         "requires": {
+            "function-bind": "^1.1.1"
+         }
+      },
+      "has-flag": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+         "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+         "dev": true
+      },
+      "has-symbols": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+         "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+         "dev": true
+      },
+      "inflight": {
+         "version": "1.0.6",
+         "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+         "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+         "dev": true,
+         "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+         }
+      },
+      "inherits": {
+         "version": "2.0.3",
+         "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+         "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+         "dev": true
+      },
+      "is-buffer": {
+         "version": "1.1.6",
+         "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+         "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+         "dev": true
+      },
+      "is-callable": {
+         "version": "1.1.4",
+         "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+         "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+         "dev": true
+      },
+      "is-date-object": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+         "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+         "dev": true
+      },
+      "is-dotfile": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+         "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+         "dev": true
+      },
+      "is-equal-shallow": {
+         "version": "0.1.3",
+         "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+         "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+         "dev": true,
+         "requires": {
+            "is-primitive": "^2.0.0"
+         }
+      },
+      "is-extendable": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+         "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+         "dev": true
+      },
+      "is-extglob": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+         "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+         "dev": true
+      },
+      "is-glob": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+         "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+         "dev": true,
+         "requires": {
+            "is-extglob": "^1.0.0"
+         }
+      },
+      "is-module": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+         "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+         "dev": true
+      },
+      "is-number": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+         "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+         "dev": true,
+         "requires": {
+            "kind-of": "^3.0.2"
+         }
+      },
+      "is-posix-bracket": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+         "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+         "dev": true
+      },
+      "is-primitive": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+         "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+         "dev": true
+      },
+      "is-regex": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+         "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+         "dev": true,
+         "requires": {
+            "has": "^1.0.1"
+         }
+      },
+      "is-symbol": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+         "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+         "dev": true,
+         "requires": {
+            "has-symbols": "^1.0.0"
+         }
+      },
+      "isarray": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+         "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+         "dev": true
+      },
+      "isobject": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+         "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+         "dev": true,
+         "requires": {
+            "isarray": "1.0.0"
+         }
+      },
+      "jest-worker": {
+         "version": "23.2.0",
+         "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
+         "integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
+         "dev": true,
+         "requires": {
+            "merge-stream": "^1.0.1"
+         }
+      },
+      "js-tokens": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+         "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+         "dev": true
+      },
+      "jsonify": {
+         "version": "0.0.0",
+         "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+         "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+         "dev": true
+      },
+      "kind-of": {
+         "version": "3.2.2",
+         "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+         "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+         "dev": true,
+         "requires": {
+            "is-buffer": "^1.1.5"
+         }
+      },
+      "magic-string": {
+         "version": "0.25.1",
+         "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
+         "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
+         "dev": true,
+         "requires": {
+            "sourcemap-codec": "^1.4.1"
+         }
+      },
+      "math-random": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+         "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+         "dev": true
+      },
+      "merge-stream": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+         "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+         "dev": true,
+         "requires": {
+            "readable-stream": "^2.0.1"
+         }
+      },
+      "micromatch": {
+         "version": "2.3.11",
+         "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+         "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+         "dev": true,
+         "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+         }
+      },
+      "minimatch": {
+         "version": "3.0.4",
+         "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+         "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+         "dev": true,
+         "requires": {
+            "brace-expansion": "^1.1.7"
+         }
+      },
+      "minimist": {
+         "version": "1.2.0",
+         "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+         "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+         "dev": true
+      },
+      "normalize-path": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+         "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+         "dev": true,
+         "requires": {
+            "remove-trailing-separator": "^1.0.1"
+         }
+      },
+      "object-inspect": {
+         "version": "1.6.0",
+         "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+         "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+         "dev": true
+      },
+      "object-keys": {
+         "version": "1.0.12",
+         "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+         "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+         "dev": true
+      },
+      "object.omit": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+         "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+         "dev": true,
+         "requires": {
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
+         }
+      },
+      "once": {
+         "version": "1.4.0",
+         "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+         "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+         "dev": true,
+         "requires": {
+            "wrappy": "1"
+         }
+      },
+      "parse-glob": {
+         "version": "3.0.4",
+         "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+         "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+         "dev": true,
+         "requires": {
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
+         }
+      },
+      "path-is-absolute": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+         "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+         "dev": true
+      },
+      "path-parse": {
+         "version": "1.0.6",
+         "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+         "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+         "dev": true
+      },
+      "preserve": {
+         "version": "0.2.0",
+         "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+         "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+         "dev": true
+      },
+      "process-nextick-args": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+         "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+         "dev": true
+      },
+      "randomatic": {
+         "version": "3.1.1",
+         "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+         "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+         "dev": true,
+         "requires": {
+            "is-number": "^4.0.0",
+            "kind-of": "^6.0.0",
+            "math-random": "^1.0.1"
+         },
+         "dependencies": {
+            "is-number": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+               "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+               "dev": true
+            },
+            "kind-of": {
+               "version": "6.0.2",
+               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+               "dev": true
+            }
+         }
+      },
+      "readable-stream": {
+         "version": "2.3.6",
+         "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+         "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+         "dev": true,
+         "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+         }
+      },
+      "regex-cache": {
+         "version": "0.4.4",
+         "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+         "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+         "dev": true,
+         "requires": {
+            "is-equal-shallow": "^0.1.3"
+         }
+      },
+      "remove-trailing-separator": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+         "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+         "dev": true
+      },
+      "repeat-element": {
+         "version": "1.1.3",
+         "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+         "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+         "dev": true
+      },
+      "repeat-string": {
+         "version": "1.6.1",
+         "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+         "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+         "dev": true
+      },
+      "resolve": {
+         "version": "1.7.1",
+         "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+         "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+         "dev": true,
+         "requires": {
+            "path-parse": "^1.0.5"
+         }
+      },
+      "resumer": {
+         "version": "0.0.0",
+         "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+         "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+         "dev": true,
+         "requires": {
+            "through": "~2.3.4"
+         }
+      },
+      "rollup": {
+         "version": "0.66.6",
+         "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.66.6.tgz",
+         "integrity": "sha512-J7/SWanrcb83vfIHqa8+aVVGzy457GcjA6GVZEnD0x2u4OnOd0Q1pCrEoNe8yLwM6z6LZP02zBT2uW0yh5TqOw==",
+         "dev": true,
+         "requires": {
+            "@types/estree": "0.0.39",
+            "@types/node": "*"
+         }
+      },
+      "rollup-plugin-commonjs": {
+         "version": "9.2.0",
+         "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.2.0.tgz",
+         "integrity": "sha512-0RM5U4Vd6iHjL6rLvr3lKBwnPsaVml+qxOGaaNUWN1lSq6S33KhITOfHmvxV3z2vy9Mk4t0g4rNlVaJJsNQPWA==",
+         "dev": true,
+         "requires": {
+            "estree-walker": "^0.5.2",
+            "magic-string": "^0.25.1",
+            "resolve": "^1.8.1",
+            "rollup-pluginutils": "^2.3.3"
+         },
+         "dependencies": {
+            "resolve": {
+               "version": "1.8.1",
+               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+               "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+               "dev": true,
+               "requires": {
+                  "path-parse": "^1.0.5"
+               }
+            }
+         }
+      },
+      "rollup-plugin-node-resolve": {
+         "version": "3.4.0",
+         "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.4.0.tgz",
+         "integrity": "sha512-PJcd85dxfSBWih84ozRtBkB731OjXk0KnzN0oGp7WOWcarAFkVa71cV5hTJg2qpVsV2U8EUwrzHP3tvy9vS3qg==",
+         "dev": true,
+         "requires": {
+            "builtin-modules": "^2.0.0",
+            "is-module": "^1.0.0",
+            "resolve": "^1.1.6"
+         }
+      },
+      "rollup-plugin-terser": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-3.0.0.tgz",
+         "integrity": "sha512-Ed9zRD7OoCBnh0XGlEAJle5TCUsFXMLClwKzZWnS1zbNO4MelHjfCSdFZxCAdH70M40nhZ1nRrY2GZQJhSMcjA==",
+         "dev": true,
+         "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "jest-worker": "^23.2.0",
+            "serialize-javascript": "^1.5.0",
+            "terser": "^3.8.2"
+         }
+      },
+      "rollup-pluginutils": {
+         "version": "2.3.3",
+         "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz",
+         "integrity": "sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==",
+         "dev": true,
+         "requires": {
+            "estree-walker": "^0.5.2",
+            "micromatch": "^2.3.11"
+         }
+      },
+      "safe-buffer": {
+         "version": "5.1.2",
+         "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+         "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+         "dev": true
+      },
+      "serialize-javascript": {
+         "version": "1.5.0",
+         "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
+         "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
+         "dev": true
+      },
+      "source-map": {
+         "version": "0.6.1",
+         "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+         "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+         "dev": true
+      },
+      "source-map-support": {
+         "version": "0.5.9",
+         "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+         "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+         "dev": true,
+         "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+         }
+      },
+      "sourcemap-codec": {
+         "version": "1.4.3",
+         "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.3.tgz",
+         "integrity": "sha512-vFrY/x/NdsD7Yc8mpTJXuao9S8lq08Z/kOITHz6b7YbfI9xL8Spe5EvSQUHOI7SbpY8bRPr0U3kKSsPuqEGSfA==",
+         "dev": true
+      },
+      "sprintf": {
+         "version": "0.1.5",
+         "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
+         "integrity": "sha1-j4PjmpMXwaUCy324BQ5Rxnn27c8=",
+         "dev": true
+      },
+      "string.prototype.trim": {
+         "version": "1.1.2",
+         "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+         "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+         "dev": true,
+         "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.0",
+            "function-bind": "^1.0.2"
+         }
+      },
+      "string_decoder": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+         "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+         "dev": true,
+         "requires": {
+            "safe-buffer": "~5.1.0"
+         }
+      },
+      "supports-color": {
+         "version": "5.5.0",
+         "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+         "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+         "dev": true,
+         "requires": {
+            "has-flag": "^3.0.0"
+         }
+      },
+      "tap-parser": {
+         "version": "0.4.3",
+         "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-0.4.3.tgz",
+         "integrity": "sha1-pOrhkMENdsehEZIf84u+TVjwnuo=",
+         "dev": true,
+         "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "~1.1.11"
+         },
+         "dependencies": {
+            "isarray": {
+               "version": "0.0.1",
+               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+               "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+               "dev": true
+            },
+            "readable-stream": {
+               "version": "1.1.14",
+               "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+               "dev": true,
+               "requires": {
+                  "core-util-is": "~1.0.0",
+                  "inherits": "~2.0.1",
+                  "isarray": "0.0.1",
+                  "string_decoder": "~0.10.x"
+               }
+            },
+            "string_decoder": {
+               "version": "0.10.31",
+               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+               "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+               "dev": true
+            }
+         }
+      },
+      "tape": {
+         "version": "4.9.1",
+         "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
+         "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
+         "dev": true,
+         "requires": {
+            "deep-equal": "~1.0.1",
+            "defined": "~1.0.0",
+            "for-each": "~0.3.3",
+            "function-bind": "~1.1.1",
+            "glob": "~7.1.2",
+            "has": "~1.0.3",
+            "inherits": "~2.0.3",
+            "minimist": "~1.2.0",
+            "object-inspect": "~1.6.0",
+            "resolve": "~1.7.1",
+            "resumer": "~0.0.0",
+            "string.prototype.trim": "~1.1.2",
+            "through": "~2.3.8"
+         }
+      },
+      "terser": {
+         "version": "3.10.2",
+         "resolved": "https://registry.npmjs.org/terser/-/terser-3.10.2.tgz",
+         "integrity": "sha512-+QrFoqBImmsQGB4c/HvaqgZynmbNvNBwoBxuu7fYXtq5EEtlLUzph+WimDj+xMkuqawXPMl2lgCIz81CdXvt+w==",
+         "dev": true,
+         "requires": {
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.6"
+         }
+      },
+      "through": {
+         "version": "2.3.8",
+         "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+         "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+         "dev": true
+      },
+      "through2": {
+         "version": "0.2.3",
+         "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+         "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
+         "dev": true,
+         "requires": {
+            "readable-stream": "~1.1.9",
+            "xtend": "~2.1.1"
+         },
+         "dependencies": {
+            "isarray": {
+               "version": "0.0.1",
+               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+               "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+               "dev": true
+            },
+            "readable-stream": {
+               "version": "1.1.14",
+               "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+               "dev": true,
+               "requires": {
+                  "core-util-is": "~1.0.0",
+                  "inherits": "~2.0.1",
+                  "isarray": "0.0.1",
+                  "string_decoder": "~0.10.x"
+               }
+            },
+            "string_decoder": {
+               "version": "0.10.31",
+               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+               "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+               "dev": true
+            }
+         }
+      },
+      "util-deprecate": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+         "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+         "dev": true
+      },
+      "wrappy": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+         "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+         "dev": true
+      },
+      "xtend": {
+         "version": "2.1.2",
+         "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+         "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+         "dev": true,
+         "requires": {
+            "object-keys": "~0.4.0"
+         },
+         "dependencies": {
+            "object-keys": {
+               "version": "0.4.0",
+               "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+               "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+               "dev": true
+            }
+         }
+      }
+   }
+}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,13 @@
    "name": "unidiff",
    "version": "0.0.4",
    "description": "diff with unified diff format handling",
-   "main": "unidiff.js",
+   "main": "dist/index.js",
    "devDependencies": {
+      "faucet": "0.0.1",
+      "rollup": "^0.66.6",
+      "rollup-plugin-commonjs": "^9.2.0",
+      "rollup-plugin-node-resolve": "^3.4.0",
+      "rollup-plugin-terser": "^3.0.0",
       "tape": "^4.4.0"
    },
    "repository": {
@@ -15,8 +20,15 @@
    },
    "scripts": {
       "link": "npm link tape",
-      "test": "tape test/test_*.js | faucet"
+      "test": "tape test/test_*.js | faucet",
+      "build": "node rollup.js",
+      "prepublishOnly": "npm run build"
    },
+   "files": [
+      "unidiff.js",
+      "hunk.js",
+      "dist"
+   ],
    "keywords": [
       "example"
    ],

--- a/rollup.js
+++ b/rollup.js
@@ -1,0 +1,21 @@
+const {rollup} = require('rollup');
+const resolve = require('rollup-plugin-node-resolve');
+const commonjs = require('rollup-plugin-commonjs');
+const {terser} = require('rollup-plugin-terser');
+
+const inputOptions = {
+    input: 'unidiff.js',
+    plugins: [
+        resolve({main: true, module: true}),
+        commonjs(),
+        terser()
+    ]
+};
+
+const build = async () => {
+    const bundle = await rollup(inputOptions);
+
+    bundle.write({format: 'umd', name: 'unidiff', file: 'dist/index.js', sourcemap: true, exports: 'named'});
+};
+
+build();


### PR DESCRIPTION
When used in browser environment without build tools like webpack ,we need a UMD bundle

This commit introduces rollup to create a UMD bundle, this output distribution (`dist/index.js`) is a 16KB file including both `jsdiff` and `unidiff`

Also I fixed some little issues:

1. Added `faucet` to `devDependencies` so that `npm test` can run without any global install
2. Added a `file` entry in `package.json` to prevent test to be published