### PR TITLE
Allow diff 3.x and 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
    "description": "diff with unified diff format handling",
    "main": "dist/index.js",
    "dependencies": {
-      "diff": "^2.2.2"
+      "diff": ">=2.2.2 <5.0.0"
    },
    "devDependencies": {
       "rollup": "^0.66.6",


### PR DESCRIPTION
I don't know if package-lock.json (which IMHO shouldn't be in git) also needs to be updated.